### PR TITLE
use amd64 as default value for DAPPER_HOST_ARCH, bump to go1.6.3

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,7 +1,7 @@
 FROM ubuntu:16.04
 # FROM arm=armhf/ubuntu:16.04
 
-ARG DAPPER_HOST_ARCH
+ARG DAPPER_HOST_ARCH=amd64
 ENV HOST_ARCH=${DAPPER_HOST_ARCH} ARCH=${DAPPER_HOST_ARCH}
 
 RUN apt-get update && \
@@ -11,7 +11,7 @@ RUN apt-get update && \
 ENV GOLANG_ARCH_amd64=amd64 GOLANG_ARCH_arm=armv6l GOLANG_ARCH=GOLANG_ARCH_${ARCH} \
     GOPATH=/go PATH=/go/bin:/usr/local/go/bin:${PATH} SHELL=/bin/bash
 
-RUN wget -O - https://storage.googleapis.com/golang/go1.6.2.linux-${!GOLANG_ARCH}.tar.gz | tar -xzf - -C /usr/local && \
+RUN wget -O - https://storage.googleapis.com/golang/go1.6.3.linux-${!GOLANG_ARCH}.tar.gz | tar -xzf - -C /usr/local && \
     go get github.com/rancher/trash && go get github.com/golang/lint/golint
 
 ENV DOCKER_URL_amd64=https://get.docker.com/builds/Linux/x86_64/docker-1.10.3 \


### PR DESCRIPTION
use amd64 as default value for DAPPER_HOST_ARCH,
bump to go1.6.3
