### PR TITLE
Adding option to override REPO and TAG

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -20,6 +20,7 @@ ENV DOCKER_URL_amd64=https://get.docker.com/builds/Linux/x86_64/docker-1.10.3 \
 
 RUN wget -O - ${!DOCKER_URL} > /usr/bin/docker && chmod +x /usr/bin/docker
 
+ENV DAPPER_ENV REPO TAG
 ENV DAPPER_SOURCE /go/src/github.com/rancher/%APP%/
 ENV DAPPER_OUTPUT ./bin ./dist
 ENV DAPPER_DOCKER_SOCKET true


### PR DESCRIPTION
We use the variables REPO and TAG in many of our repositories to change the values. This is very useful during development.
@deniseschannon @joshwget can you please review this?