### PR TITLE
update Go and Alpine version, and copyright date

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,4 +1,4 @@
-FROM golang:1.13.4-alpine3.10
+FROM golang:1.14-alpine
 
 ARG DAPPER_HOST_ARCH
 ENV ARCH $DAPPER_HOST_ARCH

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Skeleton for Rancher Go Microservices
 That will create a folder `./test123` that will be the skeleton for a new go project expected to be at `github.com/rancher/test123`
 
 ## License
-Copyright (c) 2014-2019 [Rancher Labs, Inc.](http://rancher.com)
+Copyright (c) 2014-2020 [Rancher Labs, Inc.](http://rancher.com)
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/README.md.in
+++ b/README.md.in
@@ -13,7 +13,7 @@
 `./bin/%APP%`
 
 ## License
-Copyright (c) 2019 [Rancher Labs, Inc.](http://rancher.com)
+Copyright (c) 2020 [Rancher Labs, Inc.](http://rancher.com)
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
Updates the Go version to the latest, 1.14.1, and updates Alpine to 3.11. @ibuildthecloud 