### PR TITLE
Go 1.13 Updates

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,23 +1,19 @@
-FROM golang:1.13.4-alpine3.10
+FROM golang:1.13-alpine3.10
 
 ARG DAPPER_HOST_ARCH
 ENV ARCH $DAPPER_HOST_ARCH
 
 RUN apk -U add bash git gcc musl-dev docker vim less file curl wget ca-certificates
-RUN go get -d golang.org/x/lint/golint && \
-    git -C /go/src/golang.org/x/lint/golint checkout -b current 06c8688daad7faa9da5a0c2f163a3d14aac986ca && \
-    go install golang.org/x/lint/golint && \
-    rm -rf /go/src /go/pkg
 RUN mkdir -p /go/src/golang.org/x && \
     cd /go/src/golang.org/x && git clone https://github.com/golang/tools && \
     git -C /go/src/golang.org/x/tools checkout -b current aa82965741a9fecd12b026fbb3d3c6ed3231b8f8 && \
     go install golang.org/x/tools/cmd/goimports
 RUN rm -rf /go/src /go/pkg
 RUN if [ "${ARCH}" == "amd64" ]; then \
-        curl -sL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s v1.15.0; \
+        curl -sL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s v1.20.0; \
     fi
 
-ENV GO111MODULE off
+ENV GO111MODULE on
 ENV DAPPER_ENV REPO TAG DRONE_TAG
 ENV DAPPER_SOURCE /go/src/%PKG%/
 ENV DAPPER_OUTPUT ./bin ./dist

--- a/scripts/build
+++ b/scripts/build
@@ -11,8 +11,8 @@ if [ "$(uname)" = "Linux" ]; then
 fi
 LINKFLAGS="-X github.com/rancher/%APP%.Version=$VERSION"
 LINKFLAGS="-X github.com/rancher/%APP%.GitCommit=$COMMIT $LINKFLAGS"
-CGO_ENABLED=0 go build -ldflags "$LINKFLAGS $OTHER_LINKFLAGS" -o bin/%APP%
+CGO_ENABLED=0 go build -mod vendor -ldflags "$LINKFLAGS $OTHER_LINKFLAGS" -o bin/%APP%
 if [ "$CROSS" = "true" ] && [ "$ARCH" = "amd64" ]; then
-    GOOS=darwin go build -ldflags "$LINKFLAGS" -o bin/%APP%-darwin
-    GOOS=windows go build -ldflags "$LINKFLAGS" -o bin/%APP%-windows
+    GOOS=darwin go build -mod vendor -ldflags "$LINKFLAGS" -o bin/%APP%-darwin
+    GOOS=windows go build -mod vendor -ldflags "$LINKFLAGS" -o bin/%APP%-windows
 fi


### PR DESCRIPTION
* pinned a go 1.13.x alpine build container
* removed unused golint installation
* turned on GO111MODULES
* added `-mod vendor` to `go build` so you dont have to download them
* upgraged `golangci-lint` to 1.20.0 