### PR TITLE
Update version override to work properly

### DIFF
--- a/main.go
+++ b/main.go
@@ -7,26 +7,25 @@ package main
 import (
 	"context"
 	"flag"
-	"fmt"
 	"%PKG%/pkg/foo"
 	"%PKG%/pkg/generated/controllers/some.api.group"
+	"%PKG%/pkg/version"
 	"github.com/rancher/wrangler/pkg/kubeconfig"
 	"github.com/rancher/wrangler/pkg/signals"
 	"github.com/rancher/wrangler/pkg/start"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
+	"os"
 )
 
 var (
-	Version = "v0.0.0-dev"
-	GitCommit = "HEAD"
 	KubeConfig string
 )
 
 func main() {
 	app := cli.NewApp()
 	app.Name = "testy"
-	app.Version = fmt.Sprintf("%s (%s)", Version, GitCommit)
+	app.Version = version.FriendlyVersion()
 	app.Usage = "testy needs help!"
 	app.Flags = []cli.Flag{
 		cli.StringFlag{

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,0 +1,12 @@
+package version
+
+import "fmt"
+
+var (
+	Version   = "v0.0.0-dev"
+	GitCommit = "HEAD"
+)
+
+func FriendlyVersion() string {
+	return fmt.Sprintf("%s (%s)", Version, GitCommit)
+}

--- a/scripts/build
+++ b/scripts/build
@@ -9,8 +9,8 @@ mkdir -p bin
 if [ "$(uname)" = "Linux" ]; then
     OTHER_LINKFLAGS="-extldflags -static -s"
 fi
-LINKFLAGS="-X github.com/rancher/%APP%.Version=$VERSION"
-LINKFLAGS="-X github.com/rancher/%APP%.GitCommit=$COMMIT $LINKFLAGS"
+LINKFLAGS="-X github.com/rancher/%APP%/pkg/version.Version=$VERSION"
+LINKFLAGS="-X github.com/rancher/%APP%/pkg/version.GitCommit=$COMMIT $LINKFLAGS"
 CGO_ENABLED=0 go build -ldflags "$LINKFLAGS $OTHER_LINKFLAGS" -o bin/%APP%
 if [ "$CROSS" = "true" ] && [ "$ARCH" = "amd64" ]; then
     GOOS=darwin go build -ldflags "$LINKFLAGS" -o bin/%APP%-darwin


### PR DESCRIPTION
The version override that existed before stopped working, and thus compilation would always end up with a binary reporting version `v0.0.0-dev`. This PR moves the version variables into their own package, and also pulls the `FriendlyVersion` function from `rancher/rancher` (see https://github.com/rancher/rancher/blob/9ae426a98615ea148d3a74731b743631e0d4f0c2/pkg/version/version.go) and removes the `fmt` import from `main.go`.